### PR TITLE
Update nuget pkg version

### DIFF
--- a/pipelines/secure-scan.yml
+++ b/pipelines/secure-scan.yml
@@ -19,7 +19,7 @@ steps:
       packageType: 'nuget'
       feed: '529bf55b-43ce-4ca9-a3fd-3c4ed16e057e/16e32dcf-19b6-4e02-b265-9d7f350b9d17'
       definition: 'e3212b3d-265a-4313-a777-8700eb28cc56'
-      version: '5.2107.1022.1000'
+      version: '5.2111.1040.1000'
       downloadPath: '$(System.ArtifactsDirectory)'
 
   - task: PowerShell@2


### PR DESCRIPTION
Update ExtensionInstaller nuget package version. Contributors no longer need to generate their own code sign policy XML file.